### PR TITLE
HSV 値のユークリッド距離で最適絵文字を取得。

### DIFF
--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -4,7 +4,6 @@ import 'package:flutter/material.dart';
 
 // ロジック系の関数
 class Utils {
-  int? artWh = 100;
   Map<String, Map<String, dynamic>>? emojis = {
     "red": {"rgb": Color.fromARGB(255, 255, 0, 0), "emoji": "🟥"},
     "orange": {"rgb": Color.fromARGB(255, 255, 165, 0), "emoji": "🟧"},
@@ -18,10 +17,20 @@ class Utils {
   };
 
   double _colorDistance(Color pixel, Color emoji) {
-    double doubledEuclideanDistance = 0;
-    doubledEuclideanDistance += pow((pixel.red - emoji.red), 2);
-    doubledEuclideanDistance += pow((pixel.green - emoji.green), 2);
-    doubledEuclideanDistance += pow((pixel.blue - emoji.blue), 2);
+    double doubledEuclideanDistance = 0.0;
+    // doubledEuclideanDistance += pow((pixel.red - emoji.red), 2);
+    // doubledEuclideanDistance += pow((pixel.green - emoji.green), 2);
+    // doubledEuclideanDistance += pow((pixel.blue - emoji.blue), 2);
+    HSVColor hsvPixel = HSVColor.fromColor(pixel);
+    HSVColor hsvEmoji = HSVColor.fromColor(emoji);
+    double hueDistance = min((hsvPixel.hue - hsvEmoji.hue).abs(),
+        360 - (hsvPixel.hue - hsvEmoji.hue).abs());
+
+    doubledEuclideanDistance += pow(hueDistance, 2);
+    doubledEuclideanDistance +=
+        pow((hsvPixel.saturation * 360 - hsvEmoji.saturation * 360), 2);
+    doubledEuclideanDistance +=
+        pow((hsvPixel.value * 360 - hsvEmoji.value * 360), 2);
     return sqrt(doubledEuclideanDistance);
   }
 


### PR DESCRIPTION
#14

色相、彩度、明度すべて同じ重みをつけた。
初め色相360、彩度100、明度100としていたが、あまりにも鮮やかでぎらぎらとした出力になるので変えた。

![image](https://user-images.githubusercontent.com/48375338/115999554-3222aa00-a627-11eb-93b8-f183c017cf7f.png)
左がHSV、右が従来のRGB。
一長一短という感じで、どちらがいいかよくわからない。
RGB の方では、やたら紫の絵文字が出やすい（RとBが128なので、ユークリッド距離としては小さくなる確率が高いことが原因と思われる）。HSV のほうでは一応抑えられている。