### PR TITLE
絵文字アートの大きさを指定するテキストボックスを実装。

### DIFF
--- a/lib/emoji_art.dart
+++ b/lib/emoji_art.dart
@@ -1,6 +1,7 @@
 import 'dart:math';
 
 import 'package:flutter/material.dart';
+import 'package:flutter_view/pick_max_size.dart';
 import 'package:provider/provider.dart';
 import 'package:image/image.dart' as imageUtil;
 import 'package:flutter/services.dart';
@@ -8,6 +9,7 @@ import 'package:image_size_getter/image_size_getter.dart';
 
 import 'utils.dart';
 import 'pick_image.dart';
+import 'pick_max_size.dart';
 
 // 絵文字アートのプレビューを生成
 class EmojiArtPreviewWidget extends StatelessWidget {
@@ -15,6 +17,9 @@ class EmojiArtPreviewWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     final PickedImageController pickedController =
         Provider.of<PickedImageController>(context);
+
+    final PickMaxSizeController pickedMaxSizeController =
+        Provider.of<PickMaxSizeController>(context);
 
     return FutureBuilder<MemoryImage>(
       future: pickedController.imageFuture,
@@ -28,7 +33,7 @@ class EmojiArtPreviewWidget extends StatelessWidget {
           // 縦横のマス数を決定
           final Size memoryImageSize =
               ImageSizeGetter.getSize(MemoryInput(image.bytes));
-          final int maxSize = 30; // TODO 入力できるようにする
+          final int maxSize = pickedMaxSizeController.maxSize;
           final int imageWidth = memoryImageSize.width;
           final int imageHeight = memoryImageSize.height;
 
@@ -75,6 +80,12 @@ class EmojiArtPreviewWidget extends StatelessWidget {
                     ),
                   ),
                   Text("クリックしてクリップボードにコピー"),
+                  IconButton(
+                    iconSize: 40,
+                    onPressed: pickedMaxSizeController.reloader,
+                    color: Colors.blue,
+                    icon: Icon(Icons.refresh),
+                  )
                 ],
               ),
               InkWell(

--- a/lib/emoji_art.dart
+++ b/lib/emoji_art.dart
@@ -85,7 +85,7 @@ class EmojiArtPreviewWidget extends StatelessWidget {
                     onPressed: pickedMaxSizeController.reloader,
                     color: Colors.blue,
                     icon: Icon(Icons.refresh),
-                  )
+                  ),
                 ],
               ),
               InkWell(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,6 +3,7 @@ import 'package:provider/provider.dart';
 
 import 'view.dart';
 import 'pick_image.dart';
+import 'pick_max_size.dart';
 
 void main() {
   runApp(MyApp());
@@ -21,7 +22,11 @@ class MyApp extends StatelessWidget {
           child: MyDesigner(),
           providers: [
             ChangeNotifierProvider(
-                create: (context) => PickedImageController()),
+              create: (context) => PickedImageController(),
+            ),
+            ChangeNotifierProvider(
+              create: (context) => PickMaxSizeController(),
+            ),
           ],
         ));
   }

--- a/lib/pick_max_size.dart
+++ b/lib/pick_max_size.dart
@@ -9,16 +9,12 @@ class PickMaxSizeController with ChangeNotifier {
   int _maxSize = 30;
   int get maxSize => _maxSize;
 
-  String _artSize = "<100";
-  String get artSize => _artSize;
-
   Future<int> pickMaxSize(String? n) async {
     if (n == null || n == "0") {
       n = "1";
     }
 
     _maxSize = int.parse(n);
-    _artSize = n;
     return _maxSize;
   }
 

--- a/lib/pick_max_size.dart
+++ b/lib/pick_max_size.dart
@@ -25,6 +25,20 @@ class PickMaxSizeController with ChangeNotifier {
   void reloader() async {
     notifyListeners();
   }
+
+  void maxSizeIncrementer() async {
+    if (_maxSize <= 1) {
+      return;
+    }
+    _maxSize += 1;
+  }
+
+  void maxSizeDecrementer() async {
+    if (_maxSize >= 99) {
+      return;
+    }
+    _maxSize -= 1;
+  }
 }
 
 // 絵文字アート長辺の絵文字数を指定
@@ -48,6 +62,7 @@ class PickedMaxSizeWidget extends StatelessWidget {
           alignment: Alignment.center,
           width: 100,
           child: TextFormField(
+            initialValue: "30",
             textAlign: TextAlign.center,
             enabled: true,
             maxLength: 2,

--- a/lib/pick_max_size.dart
+++ b/lib/pick_max_size.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import 'package:flutter/services.dart';
+
+// テキストフィールドの値の変更を通知
+class PickMaxSizeController with ChangeNotifier {
+  int _maxSize = 30;
+  int get maxSize => _maxSize;
+
+  String _artSize = "<100";
+  String get artSize => _artSize;
+
+  Future<int> pickMaxSize(String? n) async {
+    if (n == null || n == "0") {
+      n = "1";
+    }
+
+    _maxSize = int.parse(n);
+    _artSize = n;
+    return _maxSize;
+  }
+
+  void reloader() async {
+    notifyListeners();
+  }
+}
+
+// 絵文字アート長辺の絵文字数を指定
+class PickedMaxSizeWidget extends StatelessWidget {
+  final PickMaxSizeController controller = PickMaxSizeController();
+
+  @override
+  Widget build(BuildContext context) {
+    final PickMaxSizeController controller =
+        Provider.of<PickMaxSizeController>(context);
+
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.center,
+      children: <Widget>[
+        Text("長辺の絵文字数"),
+        Padding(
+          padding: EdgeInsets.only(left: 10, right: 10),
+        ),
+        Container(
+          padding: EdgeInsets.only(top: 10, bottom: 10),
+          alignment: Alignment.center,
+          width: 100,
+          child: TextFormField(
+            textAlign: TextAlign.center,
+            enabled: true,
+            maxLength: 2,
+            keyboardType: TextInputType.number,
+            maxLines: 1,
+            onChanged: controller.pickMaxSize,
+            inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+            enableSuggestions: true,
+            decoration: InputDecoration.collapsed(hintText: ''),
+          ),
+          decoration: BoxDecoration(
+            border: Border.all(color: Colors.orange),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/view.dart
+++ b/lib/view.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 
 import 'emoji_art.dart';
 import 'pick_image.dart';
+import 'pick_max_size.dart';
 
 // ページ全体のレイアウトを生成
 class MyDesigner extends StatelessWidget {
@@ -39,7 +40,11 @@ class MyDesigner extends StatelessWidget {
                   Padding(
                     padding: EdgeInsets.all(20),
                   ),
+                  Padding(
+                    padding: EdgeInsets.all(20),
+                  ),
                   PickedImageWidget(),
+                  PickedMaxSizeWidget(),
                   Wrap(
                     direction: Axis.horizontal,
                     children: <Widget>[

--- a/lib/view.dart
+++ b/lib/view.dart
@@ -40,9 +40,6 @@ class MyDesigner extends StatelessWidget {
                   Padding(
                     padding: EdgeInsets.all(20),
                   ),
-                  Padding(
-                    padding: EdgeInsets.all(20),
-                  ),
                   PickedImageWidget(),
                   PickedMaxSizeWidget(),
                   Wrap(


### PR DESCRIPTION
#6 

- アスペクト比を保つため長辺の長さのみ指定できるようにした。
- 入力可能文字数は2文字まで。